### PR TITLE
Set macOS deployment target to 10.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+*.xcuserstate

--- a/xcodeproj-format.xcodeproj/project.pbxproj
+++ b/xcodeproj-format.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -197,6 +198,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;


### PR DESCRIPTION
Hey! Fist of all, thank you for the tool! 

There's an issue with it though, it's impossible to build it on macOS sequoia, here's an error:

```
==> Installing xcodeproj-format from odnoletkov/tap
==> xcodebuild install SYMROOT=build DSTROOT=/ INSTALL_PATH=/opt/homebrew/Cellar/xcodeproj-format/0.1/bin
Last 15 lines from /Users/eiskrenkov/Library/Logs/Homebrew/xcodeproj-format/01.xcodebuild:

command: P0:::CreateBuildDirectory /tmp/xcodeproj-format-20241023-43519-rxohn5/build ->

CYCLE POINT ->

node: / ->

directoryTreeSignature:  ->

directoryContents: / ->

node: /
/tmp/xcodeproj-format-20241023-43519-rxohn5/xcodeproj-format.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.8, but the range of supported deployment target versions is 10.13 to 15.0.99. (in target 'xcodeproj-format' from project 'xcodeproj-format')
** INSTALL FAILED **


If reporting this issue please do so at (not Homebrew/brew or Homebrew/homebrew-core):
  https://github.com/odnoletkov/homebrew-tap/issues
```

I used 10.13 as a macOS deployment target and it seems to work! Would really appreciate it if you can merge this so that `xcodeproj-format` is installable via homebrew again. Thank you so much in advance!